### PR TITLE
#35825【機関ストレージ】 最新バージョンへの対応

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -4,5 +4,5 @@ declare(strict_types=1);
 
 use OCA\RenameWithMetadata\AppInfo\Application;
 
-$app = \OC::$server->query(Application::class);
+$app = \OC::$server->get(Application::class);
 $app->register();

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,6 +15,6 @@
     <category>files</category>
     <bugs>https://github.com/RCOSDP/nextcloud-rename_with_metadata/issues</bugs>
     <dependencies>
-        <nextcloud min-version="15" max-version="19" />
+        <nextcloud min-version="25" max-version="26" />
     </dependencies>
 </info>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -10,22 +10,19 @@ use \OCA\RenameWithMetadata\Hooks\UserHooks;
 class Application extends App {
     public const APP_ID = 'rename_with_metadata';
 
-    public function __construct(array $urlParams = []) {
+    public function __construct(array $urlParams=array()) {
         parent::__construct(self::APP_ID, $urlParams);
         $container = $this->getContainer();
 
         /**
          * Controllers
-         */
-        $container->registerService('UserHooks', function() {
-            $container = $this->getContainer();
-            $server = $container->getServer();
+         **/
+        $container->registerService('UserHooks', function ($c) {
             return new UserHooks(
-                $server->getLogger(),
-                $server->getRootFolder(),
-                $server->getDatabaseConnection(),
-                $server->getUserSession(),
-                $server->getMountManager()
+                $c->query('ServerContainer')->getRootFolder(),
+                $c->query('ServerContainer')->getDatabaseConnection(),
+                $c->query('ServerContainer')->getUserSession(),
+                $c->query('ServerContainer')->getMountManager(),
             );
         });
     }
@@ -36,6 +33,6 @@ class Application extends App {
 
     public function registerHooks() {
         $container = $this->getContainer();
-        $container->query('UserHooks')->register();
+        $container->get('UserHooks')->register();
     }
 }

--- a/lib/Db/Property.php
+++ b/lib/Db/Property.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\RenameWithMetadata\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+class Property extends Entity {
+    protected $propertypath;
+    protected $propertyname;
+    protected $userid;
+    protected $propertyvalue;
+    protected $valuetype;
+    public function __construct() {}
+}

--- a/lib/Db/PropertyMapper.php
+++ b/lib/Db/PropertyMapper.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\RenameWithMetadata\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+class PropertyMapper extends QBMapper {
+
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct($db, 'properties', Property::class);
+    }
+
+    public function findProperties($property_path) {
+        $qb = $this->db->getQueryBuilder();
+
+        $qb->select('*')->from($this->tableName)->where(
+            $qb->expr()->like(
+                'propertypath',
+                $qb->createNamedParameter(
+                    '%' . $this->db->escapeLikeParameter($property_path) . '%',
+                    IQueryBuilder::PARAM_STR
+                ),
+                IQueryBuilder::PARAM_STR
+            )
+        );
+
+        try {
+            $result = $this->findEntities($qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
## Ticket

【機関ストレージ】 最新バージョンへの対応

It corresponds to the following specifications chapter:  
4.1. Nextcloud for Institution機関ストレージ改修  
→No1: 【機関ストレージ】 最新バージョンへの対応  
→rename_metadataAPIのフォルダ変更時の挙動修正

## Purpose

- 【機関ストレージ】 最新バージョンへの対応 
  - Update source code to support Nextcloud version 25

## Changes

<!-- Briefly describe or list your changes  -->
- 【機関ストレージ】 最新バージョンへの対応 
  - updated config for Nextcloud version 25
  - replaced some degraded code
- rename_metadataAPIのフォルダ変更時の挙動修正
  - fixed error occurs when updating the 'parent' folder path (ex. files/admin/parent/child)
    (refer to lib/Hooks/UserHooks.php L76~L92)

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->
<!--
  - Does this change require a data migration? If so, what data will we migrate?
  - What is the level of risk?
    - Any permission code touched?
    - Is this an additive or subtractive change, other?
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
  - What features or workflows might this change impact?
  - How will this impact performance?
-->
None

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->
None

## Side effects

<!-- Any possible side effects? -->
None

## Deployment Notes

<!-- Any special configurations for deployment? -->
None
